### PR TITLE
Use multi-stage Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+__tests__
+lib
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM node:slim
+FROM node:alpine AS builder
 
-COPY . .
+WORKDIR /home/node
 
-RUN npm install --production
+COPY action.yml package.json tsconfig.json ./
+COPY src ./src
 
-ENTRYPOINT ["node", "/lib/main.js"]
+RUN npm install
+RUN npm run build
+RUN npm prune --production
+
+FROM node:alpine
+
+WORKDIR /home/node
+
+COPY --from=builder /home/node/action.yml /home/node/package.json ./
+COPY --from=builder /home/node/lib ./lib
+COPY --from=builder /home/node/node_modules ./node_modules
+
+ENTRYPOINT ["node", "lib/main.js"]


### PR DESCRIPTION
Hi, I've tried to improve the size of the resulting Docker image by doing the following:

* Use `node:alpine` to reduce image size compared to `node:slim`
* Use stages to reduce final image size
* Perform `npm install` inside image to make sure dependencies are built for correct platform
* Use a `WORKDIR` rather than put everything in root
* Use a `.dockerignore` to reduce build context and start image building faster

Hopefully this `Dockerfile` is as easy to use as the previous one as adding any code to `src` will just work the same. The final image is now 80MB instead of 253MB.

If `node:alpine` is not acceptable then replacing it with `node:slim` again still makes it 155MB.